### PR TITLE
Enable cross-compile support

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,6 +12,7 @@ makedepends=(
   xmlto python-sphinx python-sphinx_rtd_theme graphviz imagemagick texlive-latexextra
   coreutils kmod initramfs
   git
+  riscv64-linux-gnu-gcc
 )
 options=('!strip')
 _srcname=archlinux-linux
@@ -19,6 +20,11 @@ source=(01-riscv-makefile.patch
   02-defconfig.patch)
 sha512sums=('50006cd147adc770edb936afc3e31c8ac41ac9e2e3249e99aa8736b570cc2dbfb2366946bcfce98c086b7bbe7857093daead9f2136c9ac0225eec3f92c25ff92'
   '12d6f609ef48e0e0503fa907b6d5b15114978648740a68dd03ccb5b8b97414bf50b6e8a45bdf16635a2583b6e24e80b6c011e6aa09caf17d72cc04be56c73f0d')
+
+# Support cross compilation
+export CARCH=riscv64
+export ARCH=riscv
+export CROSS_COMPILE=riscv64-linux-gnu-
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase
@@ -156,7 +162,7 @@ _package-headers() {
   done < <(find "$builddir" -type f -perm -u+x ! -name vmlinux -print0)
 
   echo "Stripping vmlinux..."
-  strip -v $STRIP_STATIC "$builddir/vmlinux"
+  riscv64-linux-gnu-strip -v $STRIP_STATIC "$builddir/vmlinux"
 
   echo "Adding symlink..."
   mkdir -p "$pkgdir/usr/src"


### PR DESCRIPTION
Sorry, I know you have marked this repo as read-only but I thought this was a change worth considering.

The proposed changes enable us to build the package on non-riscv machines, which means you can get very fast build times. The image can then be provided to the image builder to incorporate it.